### PR TITLE
Bump terser from 5.14.1 to 5.14.2

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1627,9 +1627,9 @@
     "@jridgewell/trace-mapping" "^0.3.9"
 
 "@jridgewell/resolve-uri@^3.0.3":
-  version "3.0.8"
-  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.0.8.tgz#687cc2bbf243f4e9a868ecf2262318e2658873a1"
-  integrity sha512-YK5G9LaddzGbcucK4c8h5tWFmMPBvRZ/uyWmN1/SbBdIvqGUdWGkJ5BAaccgs6XbzVLsqbPJrBSFwKv3kT9i7w==
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz#2203b118c157721addfe69d47b70465463066d78"
+  integrity sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==
 
 "@jridgewell/set-array@^1.0.0", "@jridgewell/set-array@^1.0.1":
   version "1.1.2"
@@ -9402,9 +9402,9 @@ terser-webpack-plugin@^5.1.3, terser-webpack-plugin@^5.2.5:
     terser "^5.7.2"
 
 terser@^5.0.0, terser@^5.10.0, terser@^5.7.2:
-  version "5.14.1"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.14.1.tgz#7c95eec36436cb11cf1902cc79ac564741d19eca"
-  integrity sha512-+ahUAE+iheqBTDxXhTisdA8hgvbEG1hHOQ9xmNjeUJSoi6DU/gMrKNcfZjHkyY6Alnuyc+ikYJaxxfHkT3+WuQ==
+  version "5.14.2"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.14.2.tgz#9ac9f22b06994d736174f4091aa368db896f1c10"
+  integrity sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==
   dependencies:
     "@jridgewell/source-map" "^0.3.2"
     acorn "^8.5.0"


### PR DESCRIPTION
* Bump version to 0.4.1 [skip ci]

* Release uat (#90)

* Bump tmpl from 1.0.4 to 1.0.5

Bumps [tmpl](https://github.com/daaku/nodejs-tmpl) from 1.0.4 to 1.0.5.
- [Release notes](https://github.com/daaku/nodejs-tmpl/releases)
- [Commits](https://github.com/daaku/nodejs-tmpl/commits/v1.0.5)

---
updated-dependencies:
- dependency-name: tmpl
  dependency-type: indirect
...

Signed-off-by: dependabot[bot] <support@github.com>

* Bump tar from 6.1.0 to 6.1.11

Bumps [tar](https://github.com/npm/node-tar) from 6.1.0 to 6.1.11.
- [Release notes](https://github.com/npm/node-tar/releases)
- [Changelog](https://github.com/npm/node-tar/blob/main/CHANGELOG.md)
- [Commits](https://github.com/npm/node-tar/compare/v6.1.0...v6.1.11)

---
updated-dependencies:
- dependency-name: tar
  dependency-type: indirect
...

Signed-off-by: dependabot[bot] <support@github.com>

* using ie11 polyfill

* fixed import polyfill order

* fixed SpidSelect button with in IE

* fixed spid button padding in IE

* fixed grid spid button minWidth in IE

* fixed text-align on IE

* restored minWidth

* textAlign compatibility with IE

* using only required polyfill

* using env-var to read, validate and convert envVar

* SELC-334 - removed font

* SEL-334 - modify font link

* setting default email assistance

* fixed env import

* fixed route logout to be uniform with other apps

* fixed cyclid reference

* refactored env structure

* locals committed

* fixed unit tests

* remove-prettierrc.js

* Bump path-parse from 1.0.6 to 1.0.7

Bumps [path-parse](https://github.com/jbgutierrez/path-parse) from 1.0.6 to 1.0.7.
- [Release notes](https://github.com/jbgutierrez/path-parse/releases)
- [Commits](https://github.com/jbgutierrez/path-parse/commits/v1.0.7)

---
updated-dependencies:
- dependency-name: path-parse
  dependency-type: indirect
...

Signed-off-by: dependabot[bot] <support@github.com>

* SELC-334_removed_preconnect

* fix-development-env

* removed useless TODO

* Bump follow-redirects from 1.13.2 to 1.14.7

Bumps [follow-redirects](https://github.com/follow-redirects/follow-redirects) from 1.13.2 to 1.14.7.
- [Release notes](https://github.com/follow-redirects/follow-redirects/releases)
- [Commits](https://github.com/follow-redirects/follow-redirects/compare/v1.13.2...v1.14.7)

---
updated-dependencies:
- dependency-name: follow-redirects
  dependency-type: indirect
...

Signed-off-by: dependabot[bot] <support@github.com>

* SELC-372 refactor to use common librry completed

* using index.css from common library

* Bump nanoid from 3.1.20 to 3.2.0

Bumps [nanoid](https://github.com/ai/nanoid) from 3.1.20 to 3.2.0.
- [Release notes](https://github.com/ai/nanoid/releases)
- [Changelog](https://github.com/ai/nanoid/blob/main/CHANGELOG.md)
- [Commits](https://github.com/ai/nanoid/compare/3.1.20...3.2.0)

---
updated-dependencies:
- dependency-name: nanoid
  dependency-type: indirect
...

Signed-off-by: dependabot[bot] <support@github.com>

* SELC-372 using common library azure templates (#61)

Co-authored-by: anttorre <antonio.torre@everis.com>

* SELC-409 assistance configuration (#60)

* SELC-409 assistance email configurable

* SELC-409 added ASSISTANCE_FE url

Co-authored-by: anttorre <antonio.torre@everis.com>

* Selc 369 (#62)

* SELC-369 - added selfcare-common-frontend updated

* SELC-369 - added ASSISTANCE url in index.tsx

* SELC-369 - added selfcare-common-frontend updated

* removed debugger (#63)

Co-authored-by: anttorre <antonio.torre@everis.com>

* fixed codeowners (#64)

* Update CODEOWNERS

Co-authored-by: antonioT90 <34568575+antonioT90@users.noreply.github.com>

* SELC-144 - added analytics and consent management configuration (#66)

* SELC-144 - added analytics and consent management configuration

* SELC-144 temp devops (#68)

Co-authored-by: anttorre <antonio.torre@everis.com>

* Selc 144 track events (#69)

* SELC-144-track-events - added track events in login

* SELC-144 - added callback in Login and SpidSelect trackEvent

* SELC-144 - removed event_name and duplicate window.location.assign

* SELC-144-track-events - removed useEffect import

* Update src/App.tsx

Co-authored-by: antonioT90 <34568575+antonioT90@users.noreply.github.com>

* SELC-144 - removed href presence test

Co-authored-by: antonioT90 <34568575+antonioT90@users.noreply.github.com>

* Dependabot/npm and yarn/follow redirects 1.14.8 (#71)

* Bump version to 0.4.1 [skip ci]

* Bump follow-redirects from 1.13.2 to 1.14.8

Bumps [follow-redirects](https://github.com/follow-redirects/follow-redirects) from 1.13.2 to 1.14.8.
- [Release notes](https://github.com/follow-redirects/follow-redirects/releases)
- [Commits](https://github.com/follow-redirects/follow-redirects/compare/v1.13.2...v1.14.8)

---
updated-dependencies:
- dependency-name: follow-redirects
  dependency-type: indirect
...

Signed-off-by: dependabot[bot] <support@github.com>

* version 1.0.0

Co-authored-by: pagopa-github-bot <>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Co-authored-by: anttorre <antonio.torre@everis.com>

* Dependabot/npm and yarn/url parse 1.5.7 (#73)

* Bump version to 0.4.1 [skip ci]

* Bump url-parse from 1.5.1 to 1.5.7

Bumps [url-parse](https://github.com/unshiftio/url-parse) from 1.5.1 to 1.5.7.
- [Release notes](https://github.com/unshiftio/url-parse/releases)
- [Commits](https://github.com/unshiftio/url-parse/compare/1.5.1...1.5.7)

---
updated-dependencies:
- dependency-name: url-parse
  dependency-type: indirect
...

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: pagopa-github-bot <>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Co-authored-by: anttorre <antonio.torre@everis.com>

* SELC-144 SELC-145 devops (#74)

* SELC-144 SELC-145 devops

Co-authored-by: anttorre <antonio.torre@everis.com>

* fixed external links (#75)

Co-authored-by: anttorre <antonio.torre@everis.com>

* fixed devops react_app_url_cdn var (#76)

Co-authored-by: anttorre <antonio.torre@everis.com>

* SELC-345 loggedUser info stored in local storage (#77)

* SELC-345 loggedUser info stored in local storage

Co-authored-by: anttorre <antonio.torre@everis.com>

* Bump url-parse from 1.5.7 to 1.5.10 (#79)

Co-authored-by: anttorre <antonio.torre@everis.com>

* Selc-685 Localizzazione login (#80)


Co-authored-by: loremedda <lorenzo.medda.sa@nttdata.com>

* updated common (#81)

Co-authored-by: loremedda <lorenzo.medda.sa@nttdata.com>

* yarn lock updated (#82)

Co-authored-by: anttorre <antonio.torre@everis.com>

* Dependabot/npm and yarn/minimist 1.2.6 (#84)

* Bump version to 0.4.1 [skip ci]

* Bump minimist from 1.2.5 to 1.2.6

Bumps [minimist](https://github.com/substack/minimist) from 1.2.5 to 1.2.6.
- [Release notes](https://github.com/substack/minimist/releases)
- [Commits](https://github.com/substack/minimist/compare/1.2.5...1.2.6)

---
updated-dependencies:
- dependency-name: minimist
  dependency-type: indirect
...

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: pagopa-github-bot <>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Co-authored-by: anttorre <antonio.torre@everis.com>

* disabled caching (#85)

Co-authored-by: anttorre <antonio.torre@everis.com>

* SelfHosting OneTrust scripts (#87)

Co-authored-by: anttorre <antonio.torre@everis.com>

* white_theme (#86)

Co-authored-by: anttorre <antonio.torre@everis.com>

* SELC-859 (#88)

* SELC-859

* SELC-859

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Co-authored-by: anttorre <antonio.torre@everis.com>
Co-authored-by: USERSAD\esignore <elena.signore@nttdata.com>
Co-authored-by: Elena Signore <92723520+esignore@users.noreply.github.com>
Co-authored-by: loremedda <98110186+loremedda@users.noreply.github.com>
Co-authored-by: loremedda <lorenzo.medda.sa@nttdata.com>
Co-authored-by: Diego Lagos <92735530+diegolagospagopa@users.noreply.github.com>

* Bump version to 1.1.0 [skip ci]

* Bump version to 1.1.1 [skip ci]

* Bump version to 1.2.0 [skip ci]

* Bump version to 1.1.0 [skip ci]

* Bump version to 1.2.0 [skip ci]

* Bump version to 1.3.0 [skip ci]

* Bump version to 1.4.0 [skip ci]

* Bump terser from 5.14.1 to 5.14.2

Bumps [terser](https://github.com/terser/terser) from 5.14.1 to 5.14.2.
- [Release notes](https://github.com/terser/terser/releases)
- [Changelog](https://github.com/terser/terser/blob/master/CHANGELOG.md)
- [Commits](https://github.com/terser/terser/commits)

---
updated-dependencies:
- dependency-name: terser
  dependency-type: indirect
...

Signed-off-by: dependabot[bot] <support@github.com>

* reverted package.json version

Co-authored-by: pagopa-github-bot <>
Co-authored-by: Diego Lagos <92735530+diegolagospagopa@users.noreply.github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Co-authored-by: anttorre <antonio.torre@everis.com>
Co-authored-by: USERSAD\esignore <elena.signore@nttdata.com>
Co-authored-by: Elena Signore <92723520+esignore@users.noreply.github.com>
Co-authored-by: loremedda <98110186+loremedda@users.noreply.github.com>
Co-authored-by: loremedda <lorenzo.medda.sa@nttdata.com>
Co-authored-by: Ivan Diana <iwo.diana@gmail.com>
Co-authored-by: andrea-putzu <106688558+andrea-putzu@users.noreply.github.com>