### PR TITLE
[SELC-3301] feat: Double URL management for each of the SPID identity providers

### DIFF
--- a/.devops/deploy-pipelines.yml
+++ b/.devops/deploy-pipelines.yml
@@ -45,6 +45,7 @@ variables:
 
     react_app_login_alert_banner: '$(UAT_REACT_APP_LOGIN_ALERT_BANNER)'
 
+    react_app_login_spid_enabled: '$(UAT_REACT_APP_LOGIN_SPID_ENABLED)'
     spid_test_env_enabled: 'true'
     spid_cie_entity_id: 'xx_servizicie_test'
 
@@ -80,6 +81,7 @@ variables:
 
     react_app_login_alert_banner: '$(PROD_REACT_APP_LOGIN_ALERT_BANNER)'
 
+    react_app_login_spid_enabled: '$(PROD_REACT_APP_LOGIN_SPID_ENABLED)'
     spid_test_env_enabled: 'false'
     spid_cie_entity_id: 'xx_servizicie'
 
@@ -117,6 +119,7 @@ variables:
 
     react_app_login_alert_banner: '$(DEV_REACT_APP_LOGIN_ALERT_BANNER)'
 
+    react_app_login_spid_enabled: '$(DEV_REACT_APP_LOGIN_SPID_ENABLED)'
     spid_test_env_enabled: 'true'
     spid_cie_entity_id: 'xx_servizicie_test'
 
@@ -219,6 +222,7 @@ stages:
 
               REACT_APP_URL_API_LOGIN: '$(react_app_url_api_login)'
               REACT_APP_URL_API_LOGIN_SPID: '$(react_app_url_api_login_spid)'
+              REACT_APP_LOGIN_SPID_ENABLED: '$(react_app_login_spid_enabled)'
 
               REACT_APP_URL_PRIVACY_DISCLAIMER: '$(react_app_url_privacy_disclaimer)'
               REACT_APP_URL_TERMS_AND_CONDITIONS: '$(react_app_url_terms_and_conditions)'

--- a/.devops/deploy-pipelines.yml
+++ b/.devops/deploy-pipelines.yml
@@ -41,6 +41,7 @@ variables:
     react_app_url_fe_assistance: '$(UAT_REACT_APP_URL_FE_ASSISTANCE)'
 
     react_app_url_api_login: '$(UAT_REACT_APP_URL_API_LOGIN)'
+    react_app_url_api_login_spid: '$(UAT_REACT_APP_URL_API_LOGIN_SPID)'
 
     react_app_login_alert_banner: '$(UAT_REACT_APP_LOGIN_ALERT_BANNER)'
 
@@ -75,6 +76,7 @@ variables:
     react_app_url_fe_assistance: '$(PROD_REACT_APP_URL_FE_ASSISTANCE)'
 
     react_app_url_api_login: '$(PROD_REACT_APP_URL_API_LOGIN)'
+    react_app_url_api_login_spid: '$(PROD_REACT_APP_URL_API_LOGIN_SPID)'
 
     react_app_login_alert_banner: '$(PROD_REACT_APP_LOGIN_ALERT_BANNER)'
 
@@ -111,6 +113,7 @@ variables:
     react_app_url_fe_assistance: '$(DEV_REACT_APP_URL_FE_ASSISTANCE)'
 
     react_app_url_api_login: '$(DEV_REACT_APP_URL_API_LOGIN)'
+    react_app_url_api_login_spid: '$(DEV_REACT_APP_URL_API_LOGIN_SPID)'
 
     react_app_login_alert_banner: '$(DEV_REACT_APP_LOGIN_ALERT_BANNER)'
 
@@ -215,6 +218,7 @@ stages:
               REACT_APP_LOGIN_ALERT_BANNER: '$(react_app_login_alert_banner)'
 
               REACT_APP_URL_API_LOGIN: '$(react_app_url_api_login)'
+              REACT_APP_URL_API_LOGIN_SPID: '$(react_app_url_api_login_spid)'
 
               REACT_APP_URL_PRIVACY_DISCLAIMER: '$(react_app_url_privacy_disclaimer)'
               REACT_APP_URL_TERMS_AND_CONDITIONS: '$(react_app_url_terms_and_conditions)'

--- a/.env.development.local
+++ b/.env.development.local
@@ -2,6 +2,7 @@ REACT_APP_ENV=LOCAL_DEV
 
 REACT_APP_URL_CDN=https://dev.selfcare.pagopa.it
 
+REACT_APP_LOGIN_SPID_ENABLED=true
 REACT_APP_SPID_TEST_ENV_ENABLED=true
 REACT_APP_SPID_CIE_ENTITY_ID=xx_servizicie
 REACT_APP_PRODUCTS_ASSET=https://selfcare.pagopa.it/assets/products.json

--- a/.env.development.local
+++ b/.env.development.local
@@ -13,6 +13,7 @@ REACT_APP_URL_FE_LANDING=http://selfcare/landing
 REACT_APP_URL_FE_ASSISTANCE=http://selfcare/assistance
 
 REACT_APP_URL_API_LOGIN=http://selfcare/auth
+REACT_APP_URL_API_LOGIN_SPID=http://selfcare-spid/auth
 
 REACT_APP_PAGOPA_HELP_EMAIL=assistenza@selfcare.it
 

--- a/.env.test.local
+++ b/.env.test.local
@@ -1,5 +1,6 @@
 REACT_APP_ENV=TEST
 
+REACT_APP_LOGIN_SPID_ENABLED=true
 REACT_APP_SPID_TEST_ENV_ENABLED=true
 REACT_APP_SPID_CIE_ENTITY_ID=xx_servizicie_test
 REACT_APP_PRODUCTS_ASSET=https://selfcare.pagopa.it/assets/products.json

--- a/.env.test.local
+++ b/.env.test.local
@@ -11,6 +11,7 @@ REACT_APP_URL_FE_LANDING=http://selfcare/landing
 REACT_APP_URL_FE_ASSISTANCE=http://selfcare/assistance
 
 REACT_APP_URL_API_LOGIN=http://selfcare/auth
+REACT_APP_URL_API_LOGIN_SPID=http://selfcare-spid/auth
 
 REACT_APP_PAGOPA_HELP_EMAIL=assistenza@selfcare.it
 

--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -198,20 +198,22 @@ const Login = () => {
             </Grid>
           </Grid>
         )}
-        <Grid container justifyContent="center" mb={5}>
-          <Grid item>
-            <Alert severity="warning">
-              {t('loginPage.temporaryLogin.alert')}
-              <Link
-                ml={4}
-                sx={{ fontWeight: 'fontWeightBold', cursor: 'pointer', textDecoration: 'none' }}
-                onClick={onLinkClick}
-              >
-                {t('loginPage.temporaryLogin.join')}
-              </Link>
-            </Alert>
+        {ENV.ENABLED_SPID && (
+          <Grid container justifyContent="center" mb={5}>
+            <Grid item>
+              <Alert severity="warning">
+                {t('loginPage.temporaryLogin.alert')}
+                <Link
+                  ml={4}
+                  sx={{ fontWeight: 'fontWeightBold', cursor: 'pointer', textDecoration: 'none' }}
+                  onClick={onLinkClick}
+                >
+                  {t('loginPage.temporaryLogin.join')}
+                </Link>
+              </Alert>
+            </Grid>
           </Grid>
-        </Grid>
+        )}
         {bannerContent &&
           bannerContent.map(
             (bc, index) =>

--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -38,6 +38,7 @@ export const cieIcon = () => (
 
 const Login = () => {
   const [showIDPS, setShowIDPS] = useState(false);
+  const [isCurrentVersion, setIsCurrentVersion] = useState(true);
   const [fromOnboarding, setFromOnboarding] = useState<boolean>();
   const [product, setProduct] = useState<string>('');
   const [bannerContent, setBannerContent] = useState<Array<BannerContent>>();
@@ -120,8 +121,18 @@ const Login = () => {
     window.location.assign(`${ENV.URL_FE.LANDING}`);
   };
 
+  const onBackAction = () => {
+    setShowIDPS(false);
+    setIsCurrentVersion(true);
+  };
+
+  const onLinkClick = () => {
+    setShowIDPS(true);
+    setIsCurrentVersion(false);
+  };
+
   if (showIDPS) {
-    return <SpidSelect onBack={() => setShowIDPS(false)} />;
+    return <SpidSelect onBack={onBackAction} isCurrentVersion={isCurrentVersion} />;
   }
 
   const redirectPrivacyLink = () =>
@@ -194,7 +205,7 @@ const Login = () => {
               <Link
                 ml={4}
                 sx={{ fontWeight: 'fontWeightBold', cursor: 'pointer', textDecoration: 'none' }}
-                onClick={() => setShowIDPS(true)}
+                onClick={onLinkClick}
               >
                 {t('loginPage.temporaryLogin.join')}
               </Link>

--- a/src/pages/login/SpidSelect.tsx
+++ b/src/pages/login/SpidSelect.tsx
@@ -13,7 +13,8 @@ import { ENV } from '../../utils/env';
 import { ENABLE_LANDING_REDIRECT } from '../../utils/constants';
 import { storageSpidSelectedOps } from '../../utils/storage';
 
-const Login = ({ onBack }: { onBack: () => void }) => {
+const Login = ({ onBack, isCurrentVersion }: { onBack: () => void; isCurrentVersion: boolean }) => {
+  const basePath = isCurrentVersion ? ENV.URL_API.LOGIN : ENV.URL_API.LOGIN_SPID;
   const { t } = useTranslation();
   const getSPID = (IDP: IdentityProvider) => {
     storageSpidSelectedOps.write(IDP.entityId);
@@ -23,10 +24,7 @@ const Login = ({ onBack }: { onBack: () => void }) => {
         SPID_IDP_NAME: IDP.name,
         SPID_IDP_ID: IDP.entityId,
       },
-      () =>
-        window.location.assign(
-          `${ENV.URL_API.LOGIN}/login?entityID=${IDP.entityId}&authLevel=SpidL2`
-        )
+      () => window.location.assign(`${basePath}/login?entityID=${IDP.entityId}&authLevel=SpidL2`)
     );
   };
   const goBackToLandingPage = () => {

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -7,6 +7,8 @@ export const ENV = {
   ENV: currentEnv,
   PUBLIC_URL,
 
+  ENABLED_SPID: env.get('REACT_APP_LOGIN_SPID_ENABLED').required().asBool(),
+
   ASSISTANCE: {
     ENABLE: env.get('REACT_APP_ENABLE_ASSISTANCE').required().asBool(),
     EMAIL: env.get('REACT_APP_PAGOPA_HELP_EMAIL').required().asString(),

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -29,8 +29,9 @@ export const ENV = {
 
   URL_API: {
     LOGIN: env.get('REACT_APP_URL_API_LOGIN').required().asString(),
+    LOGIN_SPID: env.get('REACT_APP_URL_API_LOGIN_SPID').required().asString(),
   },
-  
+
   URL_FOOTER: {
     PRIVACY_DISCLAIMER: env.get('REACT_APP_URL_PRIVACY_DISCLAIMER').required().asString(),
     TERMS_AND_CONDITIONS: env.get('REACT_APP_URL_TERMS_AND_CONDITIONS').required().asString(),


### PR DESCRIPTION

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
Double URL management for each of the SPID identity providers

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
In order to avoid possible disservice, if the identity provider has already changed the certificates, it will be possible by clicking on the Link present in the Alert component, to re-select the identity provider of interest again with the latter now pointing to the URL containing the certificate updated.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Local execution
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.