### PR TITLE
[SELC-3301] feat: Added the queryParam required for Intesi identity provider + alert banner shown only if you come from the onboarding flow

### DIFF
--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -214,7 +214,8 @@ const Login = () => {
             </Grid>
           </Grid>
         )}
-        {bannerContent &&
+        {fromOnboarding &&
+          bannerContent &&
           bannerContent.map(
             (bc, index) =>
               bc.enable && (

--- a/src/pages/login/SpidSelect.tsx
+++ b/src/pages/login/SpidSelect.tsx
@@ -14,17 +14,23 @@ import { ENABLE_LANDING_REDIRECT } from '../../utils/constants';
 import { storageSpidSelectedOps } from '../../utils/storage';
 
 const Login = ({ onBack, isCurrentVersion }: { onBack: () => void; isCurrentVersion: boolean }) => {
-  const basePath = isCurrentVersion ? ENV.URL_API.LOGIN_SPID : ENV.URL_API.LOGIN;
+  const basePath = isCurrentVersion ? ENV.URL_API.LOGIN : ENV.URL_API.LOGIN_SPID;
   const { t } = useTranslation();
   const getSPID = (IDP: IdentityProvider) => {
     storageSpidSelectedOps.write(IDP.entityId);
+    const redirectUrl = `${basePath}/login?entityID=${IDP.entityId}&authLevel=SpidL2`;
     trackEvent(
       'LOGIN_IDP_SELECTED',
       {
         SPID_IDP_NAME: IDP.name,
         SPID_IDP_ID: IDP.entityId,
       },
-      () => window.location.assign(`${basePath}/login?entityID=${IDP.entityId}&authLevel=SpidL2`)
+      () =>
+        window.location.assign(
+          IDP.entityId === 'intesiid'
+            ? redirectUrl.concat('&RelayState=selfcare_pagopa_it')
+            : redirectUrl
+        )
     );
   };
   const goBackToLandingPage = () => {

--- a/src/pages/login/SpidSelect.tsx
+++ b/src/pages/login/SpidSelect.tsx
@@ -14,7 +14,7 @@ import { ENABLE_LANDING_REDIRECT } from '../../utils/constants';
 import { storageSpidSelectedOps } from '../../utils/storage';
 
 const Login = ({ onBack, isCurrentVersion }: { onBack: () => void; isCurrentVersion: boolean }) => {
-  const basePath = isCurrentVersion ? ENV.URL_API.LOGIN : ENV.URL_API.LOGIN_SPID;
+  const basePath = isCurrentVersion ? ENV.URL_API.LOGIN_SPID : ENV.URL_API.LOGIN;
   const { t } = useTranslation();
   const getSPID = (IDP: IdentityProvider) => {
     storageSpidSelectedOps.write(IDP.entityId);


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
- Added the queryParam required for Intesi identity provider.
- Alert banner shown only if you come from the onboarding flow.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
In order to meet the requirements and ensure that everything works correctly and as expected.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Tested in DEV environment: if you came from onboarding, the temporary outage banner will appear, otherwise it will not appear. The Intesii identity provider will have the required queryParam
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.