### PR TITLE
[SELC-3585] feat: Added mixpanel event for open operative manual

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,5 +1,6 @@
 import { Box } from '@mui/material';
 import { Footer, Header } from '@pagopa/selfcare-common-frontend';
+import { trackEvent } from '@pagopa/selfcare-common-frontend/services/analyticsService';
 import { ENV } from '../utils/env';
 import { isPnpg } from '../utils/utils';
 
@@ -24,6 +25,9 @@ const Layout = ({ children }: Props) => (
       onDocumentationClick={
         !isPnpg
           ? () => {
+              trackEvent('OPEN_OPERATIVE_MANUAL', {
+                from: 'login',
+              });
               window.open(ENV.URL_DOCUMENTATION, '_blank');
             }
           : undefined

--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -142,7 +142,7 @@ const Login = () => {
       },
       () =>
         window.location.assign(
-          `${ENV.URL_API.LOGIN}/login?entityID=${ENV.SPID_CIE_ENTITY_ID}&authLevel=SpidL2`
+          `${ENV.URL_API.LOGIN_SPID}/login?entityID=${ENV.SPID_CIE_ENTITY_ID}&authLevel=SpidL2`
         )
     );
   };

--- a/src/pages/login/__tests__/Login.test.tsx
+++ b/src/pages/login/__tests__/Login.test.tsx
@@ -46,7 +46,7 @@ test('test click CIE button', () => {
   });
   fireEvent.click(buttonCIE);
   expect(global.window.location.assign).toBeCalledWith(
-    `${ENV.URL_API.LOGIN}/login?entityID=xx_servizicie_test&authLevel=SpidL2`
+    `${ENV.URL_API.LOGIN_SPID}/login?entityID=xx_servizicie_test&authLevel=SpidL2`
   );
 });
 
@@ -64,7 +64,7 @@ test('test term conditions and privacy links', () => {
   render(<Login />);
 
   const termsConditionLink = screen.getByText('Termini e condizioni d’uso');
-  const privacyLink = screen.getByText("Informativa Privacy");
+  const privacyLink = screen.getAllByText(/Informativa Privacy/)[0];
 
   fireEvent.click(termsConditionLink);
   expect(global.window.location.assign).toBeCalledWith(ENV.URL_FOOTER.TERMS_AND_CONDITIONS);


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
Added mixpanel event for open operative manual

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
In order to make analytics with opening operative manual, the event contains the from property which will be valorised with the point of the application from which the manual is accessed (onboarding/login/dashboard)

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Local
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.