### PR TITLE
[SELC-4425] feat: Selfcare Login is showed when no session trying to access at onboarding contract upload flow + added unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@mui/lab": "^5.0.0-alpha.157",
     "@mui/material": "^5.14.1",
     "@pagopa/mui-italia": "^1.1.0",
-    "@pagopa/selfcare-common-frontend": "^1.34.13",
+    "@pagopa/selfcare-common-frontend": "^1.34.14",
     "@types/node": "^12.20.19",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",

--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -105,7 +105,7 @@ const Login = () => {
 
     const onboardingUrlWithoutInstitution = onboardingUrl?.split('?')[0];
 
-    if (onboardingUrlWithoutInstitution && onboardingUrlWithoutInstitution.includes('onboarding')) {
+    if (onboardingUrl?.includes('onboarding') && !onboardingUrl?.includes('confirm')) {
       setFromOnboarding(true);
       switch (onboardingUrlWithoutInstitution) {
         case '/onboarding/prod-interop':

--- a/yarn.lock
+++ b/yarn.lock
@@ -1849,10 +1849,10 @@
     fp-ts "^2.12.3"
     io-ts "^2.2.18"
 
-"@pagopa/selfcare-common-frontend@^1.34.13":
-  version "1.34.13"
-  resolved "https://registry.yarnpkg.com/@pagopa/selfcare-common-frontend/-/selfcare-common-frontend-1.34.13.tgz#73d4440f6a52b6e3fc6c809c260bb433cc578b06"
-  integrity sha512-KUtdjIAJjOq1Nm53RDv9WSL05MocbldaMS8NNoVyZwL+OEjDHuuBoiYFpqOhcHBaNBKC1jWlfyyGCg6xMvmvlw==
+"@pagopa/selfcare-common-frontend@^1.34.14":
+  version "1.34.14"
+  resolved "https://registry.yarnpkg.com/@pagopa/selfcare-common-frontend/-/selfcare-common-frontend-1.34.14.tgz#e9f30bd283699cddbacf1b68495b25c3945300ff"
+  integrity sha512-j+kZdL4164rZL3vU6RLfoVFjXDYynWgx8aTZQ/WXCkbHh12UciJM6tGAVMscmNEKChPlZAJZ2vNN0K4QasD/ow==
   dependencies:
     "@emotion/react" "^11.11.1"
     "@emotion/styled" "^11.11.0"


### PR DESCRIPTION

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
Selfcare Login is showed when no session trying to access at onboarding contract upload flow + added unit tests

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
When a party click in the link received via pec mail for complete the onboarding with upload the adhesion contract, if a session is not found, it will pass from "Selfcare Login" and not the "Onboarding Login". The second mentioned is showed only when the party is making an adhesion to a product

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Tested in local environment replicating the use case, the page shown is the correct one. Furthermore, unit tests have been added to verify the correct functioning of this implementation and test the use cases already present
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.