### PR TITLE
[SELC-4514] feat: Added specific error page for suspended or revoked idp credentials

### DIFF
--- a/src/locale/it.ts
+++ b/src/locale/it.ts
@@ -29,8 +29,16 @@ export default {
     closeButton: 'Esci',
   },
   loginError: {
-    title: 'Spiacenti, qualcosa è andato storto.',
-    message:
-      'A causa di un errore del sistema non è possibile completare la procedura.<1 />Ti chiediamo di riprovare più tardi.',
+    errors: {
+      generic:{
+        title: 'Spiacenti, qualcosa è andato storto.',
+        description: 'A causa di un errore del sistema non è possibile completare la procedura.<1 /> Ti chiediamo di riprovare più tardi.'
+      },
+      suspendedOrRevoked: {
+        title: 'Identità sospesa o revocata',
+        message: 'La tua identità SPID risulta sospesa o revocata. Per maggiori <1/>informazioni, contatta il tuo fornitore di identità SPID.',
+        close: 'Chiudi',
+      }
+    }
   },
 };

--- a/src/pages/loginError/LoginError.tsx
+++ b/src/pages/loginError/LoginError.tsx
@@ -1,41 +1,64 @@
-import { Dialog, Box, Typography } from '@mui/material';
 import { trackEvent } from '@pagopa/selfcare-common-frontend/services/analyticsService';
 import { Trans, useTranslation } from 'react-i18next';
+import { EndingPage } from '@pagopa/selfcare-common-frontend';
+import { IllusError } from '@pagopa/mui-italia';
 import { storageSpidSelectedOps } from '../../utils/storage';
+import { ENV } from '../../utils/env';
 import { redirectToLogin } from '../../utils/utils';
+// import { redirectToLogin } from '../../utils/utils';
 
-const handleError = (queryParams: string) => {
+const handleError = (errorCode: string | null) => {
   const spidId = storageSpidSelectedOps.read();
-  trackEvent('LOGIN_FAILURE', { reason: queryParams, SPID_IDP_ID: spidId });
-  console.error(`login unsuccessfull! query params obtained from idp: ${queryParams}`);
+  trackEvent('LOGIN_FAILURE', { reason: errorCode, SPID_IDP_ID: spidId });
+  console.error(`login unsuccessfull! query params obtained from idp: ${errorCode}`);
 };
 
 const LoginError = () => {
   const { t } = useTranslation();
+
+  const errorCode = new URLSearchParams(window.location.search).get('errorCode');
+
   setTimeout(() => redirectToLogin(), 3000);
 
-  const title = t('loginError.title');
-  const message = (
-    <>
-      <Trans i18nKey="message">
-        A causa di un errore del sistema non è possibile completare la procedura.
-        <br />
-        Ti chiediamo di riprovare più tardi.
+  const title =
+    errorCode === '23'
+      ? t('loginError.errors.suspendedOrRevoked.title')
+      : t('loginError.errors.generic.title');
+
+  const description =
+    errorCode === '23' ? (
+      <>
+        <Trans
+          i18nKey="loginError.errors.suspendedOrRevoked.description"
+          components={{ 1: <br /> }}
+        >
+          {
+            'La tua identità SPID risulta sospesa o revocata. Per maggiori <1 />informazioni, contatta il tuo fornitore di identità SPID.'
+          }
+        </Trans>
+      </>
+    ) : (
+      <Trans i18nKey="loginError.errors.generic.description" components={{ 1: <br /> }}>
+        {
+          'A causa di un errore del sistema non è possibile completare la procedura.<1 /> Ti chiediamo di riprovare più tardi.'
+        }
       </Trans>
-    </>
-  );
-  handleError(window.location.search);
+    );
+  handleError(errorCode);
 
   return (
-    <Dialog fullScreen={true} open={true} aria-labelledby="responsive-dialog-title">
-      <Box m="auto" sx={{ textAlign: 'center', width: '100%' }}>
-        <Typography variant="h5" sx={{ fontSize: '18px', fontWeight: '600' }}>
-          {title}
-        </Typography>
-
-        <Typography variant="body2">{message}</Typography>
-      </Box>
-    </Dialog>
+    <EndingPage
+      icon={errorCode === '23' ? <IllusError size={60} /> : undefined}
+      minHeight={'100vh'}
+      variantTitle="h4"
+      title={title}
+      variantDescription="body1"
+      description={description}
+      buttonLabel={errorCode === '23' ? t('loginError.errors.suspendedOrRevoked.close') : undefined}
+      onButtonClick={
+        errorCode === '23' ? () => window.location.assign(ENV.URL_FE.LANDING) : undefined
+      }
+    />
   );
 };
 

--- a/src/pages/loginError/LoginError.tsx
+++ b/src/pages/loginError/LoginError.tsx
@@ -5,7 +5,6 @@ import { IllusError } from '@pagopa/mui-italia';
 import { storageSpidSelectedOps } from '../../utils/storage';
 import { ENV } from '../../utils/env';
 import { redirectToLogin } from '../../utils/utils';
-// import { redirectToLogin } from '../../utils/utils';
 
 const handleError = (errorCode: string | null) => {
   const spidId = storageSpidSelectedOps.read();


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
[SELC-4514] feat: Added specific error page for suspended or revoked idp

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
In order to improve user experience: when the idp credentials are suspended or revoked, this feedback page will be shown

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Tested in local environment changing the query parameters using the errorCode that expected
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

[SELC-4514]: https://pagopa.atlassian.net/browse/SELC-4514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ