### PR TITLE
[SELC-7091] Feat: The "terms of use" and "privacy policy" links are not accessible via keyboard navigation

### DIFF
--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -122,21 +122,21 @@ const Login = () => {
       setLanguage(lang);
     }
   }, [lang]);
+  const tosRoute = isPnpg
+    ? ROUTE_TERMS_AND_CONDITION.replace('/auth/', '/')
+    : ROUTE_TERMS_AND_CONDITION;
 
   const handleTosRedirect = () => {
     trackEvent('LOGIN_TOS', { SPID_IDP_NAME: 'LOGIN_TOS' }, () => {
-      const tosRoute = isPnpg
-        ? ROUTE_TERMS_AND_CONDITION.replace('/auth/', '/')
-        : ROUTE_TERMS_AND_CONDITION;
       window.location.assign(tosRoute);
     });
   };
 
+  const privacyRoute = isPnpg
+    ? ROUTE_PRIVACY_DISCLAIMER.replace('/auth/', '/')
+    : ROUTE_PRIVACY_DISCLAIMER;
   const handlePrivacyRedirect = () => {
     trackEvent('LOGIN_PRIVACY', { SPID_IDP_NAME: 'LOGIN_PRIVACY' }, () => {
-      const privacyRoute = isPnpg
-        ? ROUTE_PRIVACY_DISCLAIMER.replace('/auth/', '/')
-        : ROUTE_PRIVACY_DISCLAIMER;
       window.location.assign(privacyRoute);
     });
   };
@@ -319,6 +319,7 @@ const Login = () => {
               <Trans i18nKey="loginPage.privacyAndCondition" shouldUnescape>
                 Accedendo accetti i
                 <Link
+                  href={tosRoute}
                   sx={{
                     cursor: 'pointer',
                     textDecoration: 'none !important',
@@ -333,6 +334,7 @@ const Login = () => {
                 <br />
                 confermi di avere letto l&apos;
                 <Link
+                href={privacyRoute}
                   sx={{
                     cursor: 'pointer',
                     textDecoration: 'none !important',


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

[SELC-7091] Feat: The "terms of use" and "privacy policy" links are not accessible via keyboard navigation

#### Motivation and Context

The "terms of use" and "privacy policy" links are not accessible via keyboard navigation

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

[SELC-7091]: https://pagopa.atlassian.net/browse/SELC-7091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ