### PR TITLE
Feat: enhance onSuccess handling across login and logout flows and updated releases endpoint actions

### DIFF
--- a/.github/workflows/create_release_branch.yml
+++ b/.github/workflows/create_release_branch.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Create Release Branch
         id: create_branch
-        uses: pagopa/selfcare-commons/github-actions-template/create-release@main
+        uses: pagopa/selfcare/.github/actions/create-release@main
         with:
           version_bump: ${{ inputs.version-bump }}
           github_path_token: ${{ secrets.GH_PAT_VARIABLES }}

--- a/.github/workflows/deploy_cdn.yml
+++ b/.github/workflows/deploy_cdn.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   release_and_deploy:
-    uses: pagopa/selfcare-commons/.github/workflows/call_release_cdn_vite_frontdoor.yml@main
+    uses: pagopa/selfcare/.github/workflows/call_release_cdn_vite_frontdoor.yml@main
     name: "Release [${{ (github.event_name == 'workflow_dispatch' && inputs.env) || (startsWith(github.ref_name, 'releases/') && 'uat') || 'dev' }}]"
     secrets: inherit
     with:
@@ -46,7 +46,7 @@ jobs:
       contents: write
     needs: [release_and_deploy]
     steps:
-      - uses: pagopa/selfcare-commons/github-actions-template/promote-release@main
+      - uses: pagopa/selfcare/.github/actions/promote-release@main
         with:
           github_path_token: ${{ secrets.GH_PAT_VARIABLES }}
           release_version: ${{ vars.CURRENT_UAT_VERSION }}

--- a/.github/workflows/deploy_cdn_pnpg.yml
+++ b/.github/workflows/deploy_cdn_pnpg.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   release_and_deploy:
-    uses: pagopa/selfcare-commons/.github/workflows/call_release_cdn_vite_frontdoor.yml@main
+    uses: pagopa/selfcare/.github/workflows/call_release_cdn_vite_frontdoor.yml@main
     name: "Release [${{ (github.event_name == 'workflow_dispatch' && inputs.env) || (startsWith(github.ref_name, 'releases/') && 'uat') || 'dev' }}]"
     secrets: inherit
     with:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,8 +58,15 @@ const onLoginRequest = () => {
 
 const onOneIdentityAuthCallback = () => <OneIdentityAuthCallbackPage />;
 
-const handleLoginRequestOnSuccessRequest = () => {
+/** persists the onSuccess query param, if any, without touching the rest of the login flow */
+const storeOnSuccessRequest = () => {
   const onSuccess: string | null = new URLSearchParams(window.location.search).get('onSuccess');
+  if (onSuccess) {
+    storageOnSuccessOps.write(onSuccess);
+  }
+};
+
+const handleLoginRequestOnSuccessRequest = () => {
   const generateRandomUniqueString = () => uuidv4().replace(/-/g, '').slice(0, 15);
   const state = generateRandomUniqueString();
   const nonce = generateRandomUniqueString();
@@ -67,9 +74,7 @@ const handleLoginRequestOnSuccessRequest = () => {
   const redirect_uri = ENV.URL_FE.LOGIN + '/login/callback';
   const encodedRedirectUri = encodeURIComponent(redirect_uri);
 
-  if (onSuccess) {
-    storageOnSuccessOps.write(onSuccess);
-  }
+  storeOnSuccessRequest();
   storageStateOps.write(state);
   storageNonceOps.write(nonce);
   storageRedirectURIOps.write(redirect_uri);
@@ -107,6 +112,14 @@ const resolveRoute = (
   }
 
   if (token) {
+    // a login request states its own destination: since the storage is persistent, whatever a
+    // previous login left behind would otherwise hijack this one (typically back to the dashboard)
+    if (path === ROUTE_LOGIN) {
+      storageOnSuccessOps.delete();
+    }
+    // the requested destination must be honoured even when a session is already in place,
+    // otherwise ValidateSession has nothing to read and falls back to the dashboard
+    storeOnSuccessRequest();
     return onAlreadyInSession(token);
   }
 

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -86,6 +86,38 @@ test('test ValidateSession', () => {
   storageTokenOps.write('testToken');
   render(<App />);
   screen.getByText('VALIDATE_SESSION:testToken');
+  expect(storageOnSuccessOps.read()).toBeUndefined();
+  checkRedirect(false);
+});
+
+test('test ValidateSession with onSuccess', () => {
+  mockedLocation.pathname = ROUTE_LOGIN;
+  mockedLocation.search = 'onSuccess=prova';
+  storageTokenOps.write('testToken');
+  render(<App />);
+  screen.getByText('VALIDATE_SESSION:testToken');
+  expect(storageOnSuccessOps.read()).toBe('prova');
+  checkRedirect(false);
+});
+
+test('test ValidateSession discards the onSuccess left by a previous login', () => {
+  mockedLocation.pathname = ROUTE_LOGIN;
+  storageOnSuccessOps.write('/dashboard');
+  storageTokenOps.write('testToken');
+  render(<App />);
+  screen.getByText('VALIDATE_SESSION:testToken');
+  expect(storageOnSuccessOps.read()).toBeUndefined();
+  checkRedirect(false);
+});
+
+test('test ValidateSession keeps the onSuccess of the login round trip', () => {
+  mockedLocation.pathname = ROUTE_LOGIN_SUCCESS;
+  mockedLocation.hash = 'token=successToken';
+  storageOnSuccessOps.write('/onboarding/user');
+  storageTokenOps.write('testToken');
+  render(<App />);
+  screen.getByText('VALIDATE_SESSION:testToken');
+  expect(storageOnSuccessOps.read()).toBe('/onboarding/user');
   checkRedirect(false);
 });
 

--- a/src/pages/ValidateSession/ValidateSession.tsx
+++ b/src/pages/ValidateSession/ValidateSession.tsx
@@ -3,6 +3,7 @@ import {
   storageTokenOps,
   storageUserOps,
 } from '@pagopa/selfcare-common-frontend/lib/utils/storage';
+import { storageOnSuccessOps } from '../../utils/storage';
 import { redirectToGoogleLogout, redirectToLogout } from '../../utils/utils';
 import { readUserFromToken, redirectSuccessLogin } from '../loginSuccess/LoginSuccess';
 
@@ -20,17 +21,21 @@ const ValidateSession = ({ sessionToken }: Props) => {
     readUserFromToken(sessionToken);
   }
 
+  // both branches below force a new login: carry the requested destination over, otherwise the
+  // storage cleanup performed while logging out drops it and the user lands on the dashboard
+  const onSuccess = storageOnSuccessOps.read();
+
   if (user && tokenFragment && user.iss !== 'PAGOPA') {
     storageUserOps.delete();
     storageTokenOps.delete();
-    redirectToGoogleLogout();
+    redirectToGoogleLogout(onSuccess);
     return;
   }
 
   if (!tokenFragment && user?.iss === 'PAGOPA') {
     storageTokenOps.delete();
     storageUserOps.delete();
-    redirectToLogout();
+    redirectToLogout(onSuccess);
     return;
   }
 

--- a/src/pages/ValidateSession/__tests__/ValidateSession.test.tsx
+++ b/src/pages/ValidateSession/__tests__/ValidateSession.test.tsx
@@ -2,7 +2,9 @@ import { User } from '@pagopa/selfcare-common-frontend/lib/model/User';
 import { storageUserOps } from '@pagopa/selfcare-common-frontend/lib/utils/storage';
 import { render } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
+import { ROUTE_LOGOUT } from '../../../utils/constants';
 import { ENV } from '../../../utils/env';
+import { storageOnSuccessOps } from '../../../utils/storage';
 import ValidSession from '../ValidateSession';
 const { TextDecoder } = await import('util');
 
@@ -27,6 +29,7 @@ beforeEach(() => {
 afterEach(() => {
   vi.unstubAllGlobals();
   storageUserOps.delete();
+  storageOnSuccessOps.delete();
 });
 
 test('test validate session', () => {
@@ -45,6 +48,28 @@ test('test validate session', () => {
   expect(user.email).toBe('1@111sadcx11.com');
 
   expect(globalThis.window.location.assign).toBeCalledWith(ENV.URL_FE.DASHBOARD);
+});
+
+test('test validate session forwards the requested destination when a new login is forced', () => {
+  storageUserOps.write({
+    uid: 'UID',
+    name: 'NAME',
+    surname: 'SURNAME',
+    email: 'EMAIL',
+    taxCode: 'TAXCODE',
+    iss: 'PAGOPA',
+  });
+  storageOnSuccessOps.write('/onboarding/user');
+
+  render(
+    <MemoryRouter>
+      <ValidSession sessionToken={ENV.TEST_TOKEN} />
+    </MemoryRouter>
+  );
+
+  expect(globalThis.window.location.assign).toBeCalledWith(
+    ROUTE_LOGOUT + '?onSuccess=' + encodeURIComponent('/onboarding/user')
+  );
 });
 
 test('test validate session when already user stored', () => {

--- a/src/pages/loginSuccess/LoginSuccess.tsx
+++ b/src/pages/loginSuccess/LoginSuccess.tsx
@@ -22,13 +22,24 @@ export const readUserFromToken = (token: string) => {
   }
 };
 
-const validOnSuccessPattern = /^\/?([\w\-./?=&]|%[0-9A-Fa-f]{2})+$/;
+/**
+ * Resolves the requested destination against the platform origin, returning undefined when it
+ * points somewhere else: both absolute (https://evil.com) and protocol relative (//evil.com)
+ * values end up on a different origin, so open redirects are rejected without extra guards.
+ */
+const resolveOnSuccessRedirect = (onSuccess: string): string | undefined => {
+  try {
+    const platformOrigin = new URL(ENV.URL_FE.DASHBOARD).origin;
+    const requested = new URL(onSuccess, platformOrigin);
+    return requested.origin === platformOrigin ? requested.toString() : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
 export const redirectSuccessLogin = () => {
   const onSuccess: string | null = storageOnSuccessOps.read();
-  const redirectTo =
-    onSuccess && validOnSuccessPattern.test(onSuccess)
-      ? new URL(ENV.URL_FE.DASHBOARD).origin + '/' + onSuccess.replace(/^\//, '')
-      : ENV.URL_FE.DASHBOARD;
+  const redirectTo = (onSuccess && resolveOnSuccessRedirect(onSuccess)) || ENV.URL_FE.DASHBOARD;
 
   storageOnSuccessOps.delete();
   storageStateOps.delete();
@@ -57,7 +68,8 @@ const LoginSuccess = () => {
     readUserFromToken(selfcareToken);
     redirectSuccessLogin();
   } else {
-    redirectToLogin();
+    // the login route wipes the storage before reading the querystring, so hand the destination over
+    redirectToLogin(storageOnSuccessOps.read());
   }
   return <LoadingOverlayComponent open={true} />;
 };

--- a/src/pages/loginSuccess/__tests__/LoginSuccess.test.tsx
+++ b/src/pages/loginSuccess/__tests__/LoginSuccess.test.tsx
@@ -78,9 +78,18 @@ test('test login success when redirect registered', () => {
   testSuccessRedirect(`/${requestedPath}`, true, window.location.origin + '/' + requestedPath);
 });
 
-test('test login success when invalid redirect', () => {
-  const requestedPath = 'prova%';
-  testSuccessRedirect(requestedPath, true, ENV.URL_FE.DASHBOARD);
+test('test login success when redirect holds characters rejected by the old pattern', () => {
+  testSuccessRedirect(
+    '/onboarding/user?email=mario.rossi@pagopa.it',
+    true,
+    window.location.origin + '/onboarding/user?email=mario.rossi@pagopa.it'
+  );
+});
+
+test('test login success when redirect is cross origin', () => {
+  testSuccessRedirect('https://evil.com/phishing', true, ENV.URL_FE.DASHBOARD);
+  testSuccessRedirect('//evil.com/phishing', true, ENV.URL_FE.DASHBOARD);
+  testSuccessRedirect('javascript:alert(1)', true, ENV.URL_FE.DASHBOARD);
 });
 
 test('test login success no ENV.TEST_TOKEN', () => {

--- a/src/pages/logout/Logout.tsx
+++ b/src/pages/logout/Logout.tsx
@@ -6,10 +6,13 @@ import { storageOnSuccessOps } from '../../utils/storage';
 import { redirectToLogin } from '../../utils/utils';
 
 const Logout = () => {
+  const onSuccess = new URLSearchParams(globalThis.location.search).get('onSuccess');
+
   storageOnSuccessOps.delete();
   storageTokenOps.delete();
   storageUserOps.delete();
-  redirectToLogin();
+  // forwarded through the querystring instead of the storage, which has just been wiped
+  redirectToLogin(onSuccess);
 
   return <div />;
 };

--- a/src/pages/logout/__tests__/Logout.test.tsx
+++ b/src/pages/logout/__tests__/Logout.test.tsx
@@ -34,3 +34,17 @@ test('test logout', () => {
 
   expect(global.window.location.assign).toBeCalledWith(ROUTE_LOGIN);
 });
+
+test('test logout forwards the requested destination to the login', () => {
+  vi.stubGlobal('location', { assign: vi.fn(), search: '?onSuccess=%2Fonboarding%2Fuser' });
+  storageOnSuccessOps.write('ON_SUCCESS');
+  storageTokenOps.write('TOKEN');
+
+  render(<Logout />);
+
+  expect(storageOnSuccessOps.read()).toBeUndefined();
+  expect(storageTokenOps.read()).toBeUndefined();
+  expect(global.window.location.assign).toBeCalledWith(
+    ROUTE_LOGIN + '?onSuccess=' + encodeURIComponent('/onboarding/user')
+  );
+});

--- a/src/pages/logoutGoogle/LogoutGoogle.tsx
+++ b/src/pages/logoutGoogle/LogoutGoogle.tsx
@@ -13,9 +13,16 @@ import { redirectToGoogleLogin } from '../../utils/utils';
 export const LogoutGoogle = () => {
   const { t } = useTranslation();
 
-  storageOnSuccessOps.delete();
+  const onSuccess = new URLSearchParams(globalThis.location.search).get('onSuccess');
+
   storageTokenOps.delete();
   storageUserOps.delete();
+  // the google login leaves this app, so the destination survives in storage rather than in the url
+  if (onSuccess) {
+    storageOnSuccessOps.write(onSuccess);
+  } else {
+    storageOnSuccessOps.delete();
+  }
 
   return (
     <Layout>

--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -6,20 +6,24 @@ import {
   ROUTE_LOGOUT_GOOGLE,
 } from './constants';
 
-export const redirectToLogin = () => {
-  globalThis.location.assign(ROUTE_LOGIN);
+/** keeps the requested destination alive across a redirect that wipes the storage */
+const withOnSuccess = (route: string, onSuccess?: string | null) =>
+  onSuccess ? `${route}?onSuccess=${encodeURIComponent(onSuccess)}` : route;
+
+export const redirectToLogin = (onSuccess?: string | null) => {
+  globalThis.location.assign(withOnSuccess(ROUTE_LOGIN, onSuccess));
 };
 
 export const redirectToGoogleLogin = () => {
   globalThis.location.assign(ROUTE_LOGIN_GOOGLE);
 };
 
-export const redirectToLogout = () => {
-  globalThis.location.assign(ROUTE_LOGOUT);
+export const redirectToLogout = (onSuccess?: string | null) => {
+  globalThis.location.assign(withOnSuccess(ROUTE_LOGOUT, onSuccess));
 };
 
-export const redirectToGoogleLogout = () => {
-  globalThis.location.assign(ROUTE_LOGOUT_GOOGLE);
+export const redirectToGoogleLogout = (onSuccess?: string | null) => {
+  globalThis.location.assign(withOnSuccess(ROUTE_LOGOUT_GOOGLE, onSuccess));
 };
 
 export const redirectToErrorPage = () => {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- App: when a token is already present, honour the `?onSuccess=` carried by the query.
  On the `/login` path the stored value is discarded first, so a destination left behind
  by a previous login cannot hijack the current one.
- LoginSuccess: replaced the validation regex with a same-origin check against the
  dashboard origin. More permissive on characters the pattern used to drop silently
  (`@`, `:`, `,`, `+`), stricter on open redirects (`https://evil.com`, `//evil.com`,
  `javascript:` are all rejected).
- utils: `redirectToLogin`, `redirectToLogout` and `redirectToGoogleLogout` take an
  optional onSuccess and forward it in the querystring.
- ValidateSession / Logout / LogoutGoogle: on a forced logout the requested destination
  survives the storage cleanup performed along the way.
- LoginSuccess: when no token is found, hand the onSuccess over to `/login` instead of
  losing it.
- Tests updated accordingly.


#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.