### PR TITLE
fix: ensure mixpanel events are sent before login redirects, remove localStorage dependency for redirect_uri

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import PrivacyPolicyPage from './pages/PrivacyPolicyPage';
 import TermsAndConditionsPage from './pages/TermsAndConditionsPage';
 import ValidateSession from './pages/ValidateSession/ValidateSession';
 import {
+  getOneIdentityRedirectUri,
   ROUTE_AUTH_CALLBACK,
   ROUTE_LOGIN,
   ROUTE_LOGIN_ERROR,
@@ -70,20 +71,27 @@ const handleLoginRequestOnSuccessRequest = () => {
   const generateRandomUniqueString = () => uuidv4().replace(/-/g, '').slice(0, 15);
   const state = generateRandomUniqueString();
   const nonce = generateRandomUniqueString();
-  // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-  const redirect_uri = ENV.URL_FE.LOGIN + '/login/callback';
+  const redirect_uri = getOneIdentityRedirectUri();
   const encodedRedirectUri = encodeURIComponent(redirect_uri);
 
   storeOnSuccessRequest();
   storageStateOps.write(state);
   storageNonceOps.write(nonce);
   storageRedirectURIOps.write(redirect_uri);
-  trackEvent('LOGIN_INTENT', {
-    origin: location.origin,
-  });
 
-  window.location.assign(
-    `${ENV.ONE_IDENTITY.BASE_URL}/login?response_type=CODE&scope=openid&client_id=${ENV.ONE_IDENTITY.CLIENT_ID}&state=${state}&nonce=${nonce}&redirect_uri=${encodedRedirectUri}`
+  const oneIdentityLoginUrl = `${ENV.ONE_IDENTITY.BASE_URL}/login?response_type=CODE&scope=openid&client_id=${ENV.ONE_IDENTITY.CLIENT_ID}&state=${state}&nonce=${nonce}&redirect_uri=${encodedRedirectUri}`;
+
+  // the redirect crosses to a different domain (oneId.it), so the trackEvent call must wait for
+  // mixpanel to confirm the event has been sent before navigating away, otherwise the outgoing
+  // request gets cancelled by the browser as soon as the page starts unloading
+  trackEvent(
+    'LOGIN_INTENT',
+    {
+      origin: location.origin,
+    },
+    () => {
+      window.location.assign(oneIdentityLoginUrl);
+    }
   );
 };
 

--- a/src/pages/__tests__/TermsAndConditionsPage.test.tsx
+++ b/src/pages/__tests__/TermsAndConditionsPage.test.tsx
@@ -1,0 +1,64 @@
+import { render } from '@testing-library/react';
+import { Mock } from 'vitest';
+import { useOneTrustNotice } from '../../hooks/useOneTrustNotice';
+import TermsAndConditionsPage from '../TermsAndConditionsPage';
+
+vi.mock('../../hooks/useOneTrustNotice', () => ({
+  useOneTrustNotice: vi.fn(),
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+test('renders the OneTrust notice container using the noticeId returned by the hook', () => {
+  (useOneTrustNotice as Mock).mockReturnValue({
+    noticeId: '6f92cced-3bd1-4859-9295-baecfc74c64a',
+    isBackstage: false,
+  });
+
+  render(<TermsAndConditionsPage />);
+
+  expect(
+    document.getElementById('otnotice-6f92cced-3bd1-4859-9295-baecfc74c64a')
+  ).toBeInTheDocument();
+});
+
+test('does not render the language dropdown when reached outside a backstage context', () => {
+  (useOneTrustNotice as Mock).mockReturnValue({
+    noticeId: '6f92cced-3bd1-4859-9295-baecfc74c64a',
+    isBackstage: false,
+  });
+
+  render(<TermsAndConditionsPage />);
+
+  expect(document.querySelector('.ot-privacy-notice-language-dropdown-container')).toBeNull();
+});
+
+test('renders the language dropdown when reached from a backstage context', () => {
+  (useOneTrustNotice as Mock).mockReturnValue({
+    noticeId: '6f92cced-3bd1-4859-9295-baecfc74c64a',
+    isBackstage: true,
+  });
+
+  render(<TermsAndConditionsPage />);
+
+  expect(
+    document.querySelector('.ot-privacy-notice-language-dropdown-container')
+  ).toBeInTheDocument();
+});
+
+test('passes the normal and backstage configs to the hook, with an empty backstage noticeId', () => {
+  (useOneTrustNotice as Mock).mockReturnValue({
+    noticeId: '6f92cced-3bd1-4859-9295-baecfc74c64a',
+    isBackstage: false,
+  });
+
+  render(<TermsAndConditionsPage />);
+
+  expect(useOneTrustNotice).toHaveBeenCalledWith(
+    expect.anything(),
+    expect.objectContaining({ noticeId: '6f92cced-3bd1-4859-9295-baecfc74c64a' }),
+    expect.objectContaining({ noticeId: '' })
+  );
+});

--- a/src/pages/loginSuccess/LoginSuccess.tsx
+++ b/src/pages/loginSuccess/LoginSuccess.tsx
@@ -46,10 +46,18 @@ export const redirectSuccessLogin = () => {
   storageNonceOps.delete();
   storageRedirectURIOps.delete();
 
-  trackEvent('LOGIN_SUCCESS', {
-    origin: location.origin,
-  });
-  window.location.assign(redirectTo);
+  // the redirect crosses to a different domain in some flows, so the trackEvent call must wait
+  // for mixpanel to confirm the event has been sent before navigating away, otherwise the
+  // outgoing request gets cancelled by the browser as soon as the page starts unloading
+  trackEvent(
+    'LOGIN_SUCCESS',
+    {
+      origin: location.origin,
+    },
+    () => {
+      window.location.assign(redirectTo);
+    }
+  );
 };
 
 /** success login operations */

--- a/src/pages/loginSuccess/__tests__/LoginSuccess.test.tsx
+++ b/src/pages/loginSuccess/__tests__/LoginSuccess.test.tsx
@@ -9,9 +9,15 @@ import { ENV } from '../../../utils/env';
 import { storageOnSuccessOps } from '../../../utils/storage';
 import LoginSuccess from '../LoginSuccess';
 
-// mock analytics service
+// mock analytics service: trackEvent now takes an optional callback (invoked once mixpanel
+// confirms the event was sent) which the redirect logic relies on to fire the navigation, so the
+// mock must invoke it synchronously to keep the redirect assertions working
 vi.mock('@pagopa/selfcare-common-frontend/lib/services/analyticsService', () => ({
-  trackEvent: vi.fn(),
+  trackEvent: vi.fn((_eventName, _properties, callback) => {
+    if (callback) {
+      callback();
+    }
+  }),
 }));
 
 const { TextDecoder } = await import('util');

--- a/src/pages/logoutGoogle/__tests__/LogoutGoogle.test.tsx
+++ b/src/pages/logoutGoogle/__tests__/LogoutGoogle.test.tsx
@@ -1,0 +1,67 @@
+import {
+  storageTokenOps,
+  storageUserOps,
+} from '@pagopa/selfcare-common-frontend/lib/utils/storage';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { storageOnSuccessOps } from '../../../utils/storage';
+import { redirectToGoogleLogin } from '../../../utils/utils';
+import { LogoutGoogle } from '../LogoutGoogle';
+
+// the LoginHeader rendered by Layout relies on react-router's useLocation, so every render needs
+// a Router in the tree even though this page itself doesn't use routing
+const renderWithRouter = () => render(<LogoutGoogle />, { wrapper: MemoryRouter });
+
+vi.mock('../../../utils/utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../utils/utils')>();
+  return {
+    ...actual,
+    redirectToGoogleLogin: vi.fn(),
+  };
+});
+
+beforeEach(() => {
+  vi.stubGlobal('location', { assign: vi.fn(), search: '' });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+test('clears the session and drops any pending onSuccess when reached with no destination', () => {
+  storageTokenOps.write('TOKEN');
+  storageUserOps.write({
+    uid: 'UID',
+    name: 'NAME',
+    surname: 'SURNAME',
+    email: 'EMAIL',
+    taxCode: 'TAXCODE',
+  });
+  storageOnSuccessOps.write('STALE_ON_SUCCESS');
+
+  renderWithRouter();
+
+  expect(storageTokenOps.read()).toBeUndefined();
+  expect(storageUserOps.read()).toBeUndefined();
+  expect(storageOnSuccessOps.read()).toBeUndefined();
+});
+
+test('persists the requested destination in storage, since the google login leaves this app', () => {
+  vi.stubGlobal('location', {
+    assign: vi.fn(),
+    search: '?onSuccess=' + encodeURIComponent('/onboarding/user'),
+  });
+
+  renderWithRouter();
+
+  expect(storageOnSuccessOps.read()).toBe('/onboarding/user');
+});
+
+test('renders the ending page and triggers the google login redirect on button click', () => {
+  renderWithRouter();
+
+  const button = screen.getByRole('button', { name: 'Accedi' });
+  button.click();
+
+  expect(redirectToGoogleLogin).toHaveBeenCalled();
+});

--- a/src/pages/oneIdentityAuthCallback/OneIdentityAuthCallback.tsx
+++ b/src/pages/oneIdentityAuthCallback/OneIdentityAuthCallback.tsx
@@ -3,13 +3,8 @@ import { trackEvent } from '@pagopa/selfcare-common-frontend/lib/services/analyt
 import { storageTokenOps } from '@pagopa/selfcare-common-frontend/lib/utils/storage';
 import { NonEmptyString } from '@pagopa/ts-commons/lib/strings';
 import { selfcareAuthService } from '../../services/selfcareAuth';
-import { ROUTE_LOGIN_SUCCESS, ROUTE_OTP } from '../../utils/constants';
-import {
-  storageMaskedEmailOps,
-  storageOTPSessionUidOps,
-  storageRedirectURIOps,
-  storageStateOps,
-} from '../../utils/storage';
+import { getOneIdentityRedirectUri, ROUTE_LOGIN_SUCCESS, ROUTE_OTP } from '../../utils/constants';
+import { storageMaskedEmailOps, storageOTPSessionUidOps, storageStateOps } from '../../utils/storage';
 import { redirectToErrorPage } from '../../utils/utils';
 
 const OneIdentityAuthCallbackPage = () => {
@@ -18,17 +13,25 @@ const OneIdentityAuthCallbackPage = () => {
   const oneIdentityCode = urlParams.get('code');
   const error = urlParams.get('error');
   const storedState = storageStateOps.read();
-  const redirectURI = storageRedirectURIOps.read();
+
+  const redirectURI = getOneIdentityRedirectUri();
 
   if (error || !oneIdentityCode || !receivedState || receivedState !== storedState) {
-    trackEvent('LOGIN_ERROR_ONE_IDENTITY', {
-      error,
-      storedState,
-      receivedState,
-      oneIdentityCode,
-      redirectURI,
-    });
-    redirectToErrorPage();
+    // wait for mixpanel to confirm the event has been sent before navigating away, otherwise the
+    // outgoing request can be cancelled as soon as the page starts unloading
+    trackEvent(
+      'LOGIN_ERROR_ONE_IDENTITY',
+      {
+        error,
+        storedState,
+        receivedState,
+        oneIdentityCode,
+        redirectURI,
+      },
+      () => {
+        redirectToErrorPage();
+      }
+    );
     return <></>;
   }
 
@@ -50,14 +53,21 @@ const OneIdentityAuthCallbackPage = () => {
         }
       })
       .catch((err) => {
-        trackEvent('LOGIN_ERROR_ONE_IDENTITY', {
-          selfcareAuthServiceError: err,
-          storedState,
-          receivedState,
-          oneIdentityCode,
-          redirectURI,
-        });
-        redirectToErrorPage();
+        // wait for mixpanel to confirm the event has been sent before navigating away, otherwise
+        // the outgoing request can be cancelled as soon as the page starts unloading
+        trackEvent(
+          'LOGIN_ERROR_ONE_IDENTITY',
+          {
+            selfcareAuthServiceError: err,
+            storedState,
+            receivedState,
+            oneIdentityCode,
+            redirectURI,
+          },
+          () => {
+            redirectToErrorPage();
+          }
+        );
       });
   }
 

--- a/src/pages/oneIdentityAuthCallback/__tests__/OneIdentityAuthCallback.test.tsx
+++ b/src/pages/oneIdentityAuthCallback/__tests__/OneIdentityAuthCallback.test.tsx
@@ -3,12 +3,8 @@ import '@testing-library/jest-dom';
 import { render, screen, waitFor } from '@testing-library/react';
 import { Mock } from 'vitest';
 import { SelfcareAuthApiMock } from '../../../api/__mocks__/SelfcareAuthApiClient';
-import { ROUTE_LOGIN_SUCCESS, ROUTE_OTP } from '../../../utils/constants';
-import {
-  storageMaskedEmailOps,
-  storageRedirectURIOps,
-  storageStateOps,
-} from '../../../utils/storage';
+import { getOneIdentityRedirectUri, ROUTE_LOGIN_SUCCESS, ROUTE_OTP } from '../../../utils/constants';
+import { storageMaskedEmailOps, storageStateOps } from '../../../utils/storage';
 import { redirectToErrorPage } from '../../../utils/utils';
 import OneIdentityAuthCallbackPage from '../OneIdentityAuthCallback';
 
@@ -34,9 +30,6 @@ vi.mock('../../../utils/storage', () => ({
   storageStateOps: {
     read: vi.fn(),
   },
-  storageRedirectURIOps: {
-    read: vi.fn(),
-  },
   storageMaskedEmailOps: {
     write: vi.fn(),
   },
@@ -55,6 +48,10 @@ vi.mock('@pagopa/selfcare-common-frontend/lib', () => ({
 
 const originalWindow = { ...window };
 const mockAssign = vi.fn();
+
+// the redirect_uri is now computed deterministically (env-based) instead of being read from
+// storage, so tests assert against this same computation rather than mocking storage for it
+const expectedRedirectUri = getOneIdentityRedirectUri();
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -114,7 +111,6 @@ describe('OneIdentityAuthCallbackPage', () => {
     });
 
     (storageStateOps.read as Mock).mockReturnValue('test-state');
-    (storageRedirectURIOps.read as Mock).mockReturnValue('https://example.com/callback');
 
     (SelfcareAuthApiMock.oneIdentityCodeExchangeMock as Mock).mockResolvedValue({
       sessionToken: 'auth-token',
@@ -132,7 +128,6 @@ describe('OneIdentityAuthCallbackPage', () => {
     });
 
     (storageStateOps.read as Mock).mockReturnValue('test-state');
-    (storageRedirectURIOps.read as Mock).mockReturnValue('https://example.com/callback');
 
     (SelfcareAuthApiMock.oneIdentityCodeExchangeMock as Mock).mockResolvedValue({
       sessionToken: 'auth-token',
@@ -143,7 +138,7 @@ describe('OneIdentityAuthCallbackPage', () => {
     await waitFor(() => {
       expect(SelfcareAuthApiMock.oneIdentityCodeExchangeMock).toHaveBeenCalledWith({
         code: 'test-code',
-        redirectUri: 'https://example.com/callback',
+        redirectUri: expectedRedirectUri,
       });
     });
   });
@@ -155,9 +150,8 @@ describe('OneIdentityAuthCallbackPage', () => {
       writable: true,
     });
 
-    // Mock stored state and redirect URI
+    // Mock stored state
     (storageStateOps.read as Mock).mockReturnValue('test-state');
-    (storageRedirectURIOps.read as Mock).mockReturnValue('https://example.com/callback');
 
     // Mock API call
     (SelfcareAuthApiMock.oneIdentityCodeExchangeMock as Mock).mockResolvedValue({
@@ -180,9 +174,8 @@ describe('OneIdentityAuthCallbackPage', () => {
       writable: true,
     });
 
-    // Mock stored state and redirect URI
+    // Mock stored state
     (storageStateOps.read as Mock).mockReturnValue('test-state');
-    (storageRedirectURIOps.read as Mock).mockReturnValue('https://example.com/callback');
 
     // Mock API call to fail
     (SelfcareAuthApiMock.oneIdentityCodeExchangeMock as Mock).mockRejectedValue(
@@ -197,23 +190,6 @@ describe('OneIdentityAuthCallbackPage', () => {
     });
   });
 
-  test('should not call API when redirectURI is missing', () => {
-    // Set up window.location.search with code and state
-    Object.defineProperty(window, 'location', {
-      value: { ...window.location, search: '?code=test-code&state=test-state' },
-      writable: true,
-    });
-
-    // Mock stored state but return null for redirectURI
-    (storageStateOps.read as Mock).mockReturnValue('test-state');
-    (storageRedirectURIOps.read as Mock).mockReturnValue(null);
-
-    render(<OneIdentityAuthCallbackPage />);
-
-    // API should not be called
-    expect(SelfcareAuthApiMock.oneIdentityCodeExchangeMock).not.toHaveBeenCalled();
-  });
-
   test('should redirect to otp page when requiredOtp is true in the token exchange response', async () => {
     // Set up window.location.search with code and state
     Object.defineProperty(window, 'location', {
@@ -223,7 +199,6 @@ describe('OneIdentityAuthCallbackPage', () => {
 
     // Mock stored state. Value test-otp-code is used to trigger the oidcExchange response with requiresOtpFlow=true
     (storageStateOps.read as Mock).mockReturnValue('test-otp-code');
-    (storageRedirectURIOps.read as Mock).mockReturnValue('https://example.com/callback');
     (storageStateOps.read as Mock).mockReturnValue('test-state');
 
     (SelfcareAuthApiMock.oneIdentityCodeExchangeMock as Mock).mockResolvedValue({

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -20,3 +20,12 @@ export const ROUTE_LOGIN_GOOGLE = ENV.GOOGLE_LOGIN_URL;
 export const ENABLE_LANDING_REDIRECT = !ENV.URL_FE.LANDING.endsWith('/auth/logout');
 
 export const LOADING_TASK_VERIFY_OTP = 'VERIFY_OTP';
+
+/**
+ * The redirect_uri sent to OneIdentity is deterministic per environment, so it must be recomputed
+ * (rather than read back from storage) on the auth callback page: relying on storage for this value
+ * exposes the flow to browser anti-tracking mitigations (e.g. Safari ITP) that can purge localStorage
+ * on the selfcare.it -> oneId.it -> selfcare.it redirect bounce, leaving nothing to read on return.
+ */
+// eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+export const getOneIdentityRedirectUri = () => ENV.URL_FE.LOGIN + '/login/callback';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -43,6 +43,7 @@ export default defineConfig({
                 'src/lib/index.ts',
                 'src/lib/components/icons/**',
                 'src/lib/model/**',
+                'src/locale/**',
             ],
         },
     },


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- LOGIN_INTENT, LOGIN_ERROR_ONE_IDENTITY and LOGIN_SUCCESS trackEvent calls now use the
  callback param to defer window.location.assign until mixpanel confirms delivery,
  preventing the outgoing request from being cancelled by the page unload
- OneIdentityAuthCallback now recomputes redirect_uri from ENV instead of reading it back
  from localStorage, avoiding empty values caused by browser anti-bounce-tracking storage
  purges (e.g. Safari ITP) on the selfcare.it -> oneId.it -> selfcare.it redirect
- add tests for LogoutGoogle and TermsAndConditionsPage, exclude src/locale from coverage
<!--- Describe your changes in detail -->

#### Motivation and Context
mix panel events not being sent because of fast redirects 
<!--- Why is this change required? What problem does it solve? -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.